### PR TITLE
Fixed an off-by-1 error in writing out vectors.

### DIFF
--- a/src/utils/write_helpers.h
+++ b/src/utils/write_helpers.h
@@ -23,13 +23,12 @@ void write_vector(std::ostream &os, const std::vector<utils::copyable_ptr<T>> &p
 	if (parameters.size() > 0)
 	{
 		if (parameters.size() > 1)
-			for (auto i = 1; i < parameters.size() - 1; ++i)
+			for (auto i = 0; i < parameters.size() - 1; ++i)
 			{
 				parameters[i]->write_declaration(os);
 				os << ", ";
 			}
 		parameters[parameters.size() - 1]->write_declaration(os);
-		os << std::endl;
 	}
 }
 
@@ -39,9 +38,9 @@ void write_vector(std::ostream &os, const std::vector<T> &parameters)
 	if (parameters.size() > 0)
 	{
 		if (parameters.size() > 1)
-			for (auto i = 1; i < parameters.size() - 1; ++i)
+			for (auto i = 0; i < parameters.size() - 1; ++i)
 				os << parameters[i] << ", ";
-		os << parameters[parameters.size() - 1] << std::endl;
+		os << parameters[parameters.size() - 1];
 	}
 }
 

--- a/tests/utils/write_helpers_tests.cpp
+++ b/tests/utils/write_helpers_tests.cpp
@@ -1,0 +1,38 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/test/output_test_stream.hpp>
+#include "../../src/utils/write_helpers.h"
+#include "../../src/features/types/template_parameters.h"
+
+using namespace std;
+using namespace cpp::codeprovider::utils;
+using namespace cpp::codeprovider::types::templates;
+
+BOOST_AUTO_TEST_SUITE(write_helper_tests)
+
+BOOST_AUTO_TEST_CASE(write_vector_1_tests)
+{
+    vector<copyable_ptr<template_parameter>> params{make_unique<template_parameter>("T1"), make_unique<template_parameter>("T2")};
+
+    boost::test_tools::output_test_stream stream;
+
+    write_vector(stream, params);
+
+    auto str = stream.str();
+
+    BOOST_TEST(str == "typename T1, typename T2");
+}
+
+BOOST_AUTO_TEST_CASE(write_vector_2_tests)
+{
+    vector<string> params{"T1", "T2"};
+
+    boost::test_tools::output_test_stream stream;
+
+    write_vector(stream, params);
+
+    auto str = stream.str();
+
+    BOOST_TEST(str == "T1, T2");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes the issue where writing vectors, like template parameters, would incorrectly skip the first element if vector size was > 1.