### PR TITLE
Bugfix/jump statement fixes

### DIFF
--- a/src/features/statements/jump_statements.cpp
+++ b/src/features/statements/jump_statements.cpp
@@ -17,6 +17,11 @@ jump_statement::jump_statement(jump_type t)
 {
 }
 
+jump_statement::jump_statement(jump_type t, unique_ptr<expression> e)
+	: j_type(t), e1(move(e))
+{
+}
+
 jump_type jump_statement::type() const
 {
 	return j_type;
@@ -43,7 +48,7 @@ void jump_statement::write(ostream &os) const
 		os << "break;" << endl;
 		break;
 	case jump_type::goto_jump:
-		os << "goto " << *e1 << endl;
+		os << "goto " << *e1 << ";" << endl;
 		break;
 	case jump_type::return_jump:
 		os << "return";

--- a/src/features/statements/jump_statements.cpp
+++ b/src/features/statements/jump_statements.cpp
@@ -46,9 +46,9 @@ void jump_statement::write(ostream &os) const
 		os << "goto " << *e1 << endl;
 		break;
 	case jump_type::return_jump:
-		os << "return ";
+		os << "return";
 		if (e1)
-			os << *e1;
+			os << ' ' << *e1;
 		os << ";" << endl;
 		break;
 	}

--- a/src/features/statements/jump_statements.h
+++ b/src/features/statements/jump_statements.h
@@ -30,6 +30,7 @@ class jump_statement : public statement
 
 public:
 	jump_statement(jump_type);
+	jump_statement(jump_type, std::unique_ptr<expressions::expression>);
 
 	jump_type type() const;
 

--- a/src/features/statements/try_statement.cpp
+++ b/src/features/statements/try_statement.cpp
@@ -75,7 +75,8 @@ unique_ptr<statement> try_statement::clone() const
 
 void try_statement::write(ostream &os) const
 {
-	os << "try" << endl;
+	auto indent = formatter_settings::settings.get_indent_string();
+	os << indent << "try" << endl;
 	os << try_block;
 
 	for (auto &c : catch_blocks)

--- a/src/features/statements/try_statement.cpp
+++ b/src/features/statements/try_statement.cpp
@@ -2,11 +2,13 @@
 #include "../expressions/common.h"
 #include "../declarations/variable_declaration.h"
 #include "../types/primitive_type.h"
+#include "../../formatters/formatter_settings.h"
 
 using namespace std;
 using namespace cpp::codeprovider::declarations;
 using namespace cpp::codeprovider::statements;
 using namespace cpp::codeprovider::types;
+using namespace cpp::codeprovider::formatting;
 
 namespace
 {
@@ -35,7 +37,8 @@ const statement_list &catch_clause::statements() const
 
 std::ostream &cpp::codeprovider::statements::operator<<(std::ostream &os, const catch_clause &c)
 {
-	os << "catch(";
+	auto indent = formatter_settings::settings.get_indent_string();
+	os << indent << "catch(";
 	if (c.variable().var_declarator().name.size() > 0)
 		c.variable().write_declaration(os);
 	else

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -9,9 +9,10 @@
 BOOST_AUTO_TEST_SUITE(statement_tests)
 
 using namespace std;
+using namespace cpp::codeprovider::declarations;
 using namespace cpp::codeprovider::expressions;
 using namespace cpp::codeprovider::statements;
-using namespace cpp::codeprovider::declarations;
+using namespace cpp::codeprovider::types;
 using namespace cpp::codeprovider::formatting;
 
 BOOST_AUTO_TEST_CASE(expression_statement_tests)
@@ -391,9 +392,17 @@ BOOST_AUTO_TEST_CASE(catch_block_tests)
 	auto &var = block.variable();
 
 	boost::test_tools::output_test_stream output;
+	auto indent = formatter_settings::settings.get_indent_string();
 	output << block;
 
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + "}\n" );
+
 	auto copy1(block);
+
+	output.str("");
+	output << copy1;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + "}\n" );
 
 	auto &body2 = block.statements();
 
@@ -402,7 +411,17 @@ BOOST_AUTO_TEST_CASE(catch_block_tests)
 
 	BOOST_TEST(block.statements().size() == 2);
 
+	output.str("");
+	output << block;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" );
+
 	auto copy2(block);
+
+	output.str("");
+	output << copy2;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" );
 
 	BOOST_TEST(copy2.statements().size() == 2);
 	BOOST_TEST(block.statements().size() == 2);
@@ -410,16 +429,37 @@ BOOST_AUTO_TEST_CASE(catch_block_tests)
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
 	copy2 = block;
 
+	output.str("");
+	output << block;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n" );
+
 	BOOST_TEST(copy2.statements().size() == 3);
 	BOOST_TEST(block.statements().size() == 3);
 
+	output.str("");
 	output << copy2;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n" );
 
 	const auto &c_ref = copy1;
 	c_ref.statements();
 	c_ref.variable();
 
+	output.str("");
 	output << c_ref;
+
+	BOOST_TEST(output.str() == indent + "catch(...)\n" + indent + "{\n" + indent + "}\n" );
+
+	auto type = make_unique<primitive_type>("int");
+	auto var2 = make_unique<variable_declaration>(variable_declaration(declarator_specifier(move(type))));
+	var2->var_declarator().name = "i";
+	catch_clause catch2(move(var2));
+
+	output.str("");
+	output << catch2;
+
+	BOOST_TEST(output.str() == indent + "catch(int i)\n" + indent + "{\n" + indent + "}\n" );
 }
 
 BOOST_AUTO_TEST_CASE(try_statement_tests)

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -469,6 +469,14 @@ BOOST_AUTO_TEST_CASE(try_statement_tests)
 	BOOST_TEST(stmt->statements().size() == 0);
 	BOOST_TEST(stmt->catch_clauses().size() == 0);
 
+	boost::test_tools::output_test_stream stream;
+	auto indent = formatter_settings::settings.get_indent_string();
+
+	stream << *stmt;
+	auto str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + "}\n");
+	
 	auto &body2 = stmt->statements();
 
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
@@ -486,14 +494,37 @@ BOOST_AUTO_TEST_CASE(try_statement_tests)
 	BOOST_TEST(stmt->statements().size() == 2);
 	BOOST_TEST(stmt->catch_clauses().size() == 1);
 
+	stream.str("");
+	stream << *stmt;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	auto other = stmt->clone();
 
-	boost::test_tools::output_test_stream stream;
-
 	stream << *other;
+
+	stream.str("");
+	stream << *other;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	other->write(stream);
 
+	stream.str("");
+	stream << *other;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	stream << *stmt;
+
+	stream.str("");
+	stream << *stmt;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	auto copy1(*stmt);
 
@@ -503,25 +534,53 @@ BOOST_AUTO_TEST_CASE(try_statement_tests)
 	BOOST_TEST(stmt->statements().size() == 2);
 	BOOST_TEST(stmt->catch_clauses().size() == 1);
 
+	stream.str("");
+	stream << copy1;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	auto copy2(*stmt);
 
 	stmt->catch_clauses().push_back(block);
 	body2.emplace_back(make_unique<expression_statement>(make_unique<primitive_expression>("2")));
 
+	stream.str("");
+	stream << copy2;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	copy2 = *stmt;
+
+	stream.str("");
+	stream << copy2;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	BOOST_TEST(copy2.statements().size() == 3);
 	BOOST_TEST(stmt->statements().size() == 3);
 	BOOST_TEST(copy2.catch_clauses().size() == 2);
 	BOOST_TEST(stmt->catch_clauses().size() == 2);
 
+
+	stream.str("");
 	stream << copy2;
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	const auto &c_ref = copy1;
 	c_ref.catch_clauses();
 	c_ref.clone();
 	c_ref.statements();
+
+	stream.str("");
 	c_ref.write(stream);
+	str = stream.str();
+
+	BOOST_TEST(str == indent + "try\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 }
 
 BOOST_AUTO_TEST_CASE(case_statement_tests)

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -761,19 +761,100 @@ BOOST_AUTO_TEST_CASE(jump_statement_tests)
 	BOOST_TEST(return_stmt1.type() == jump_type::return_jump);
 
 	boost::test_tools::output_test_stream output;
+	auto indent = formatter_settings::settings.get_indent_string();
+
 	output << break_stmt;
+	BOOST_TEST(output.str() == indent + "break;\n");
+
+	output.str("");
+	output << continue_stmt;
+	BOOST_TEST(output.str() == indent + "continue;\n");
+
+	output.str("");
+	output << goto_stmt;
+	BOOST_TEST(output.str() == indent + "goto label;\n");
+
+	output.str("");
+	output << return_stmt1;
+	BOOST_TEST(output.str() == indent + "return;\n");
+
+	output.str("");
+	output << return_stmt2;
+	BOOST_TEST(output.str() == indent + "return 5;\n");
 
 	auto copy1(break_stmt);
+	auto copy2(continue_stmt);
+	auto copy3(goto_stmt);
+	auto copy4(return_stmt1);
+	auto copy5(return_stmt2);
 
 	BOOST_TEST(copy1.type() == jump_type::break_jump);
 	BOOST_TEST(break_stmt.type() == jump_type::break_jump);
+	BOOST_TEST(copy2.type() == jump_type::continue_jump);
+	BOOST_TEST(continue_stmt.type() == jump_type::continue_jump);
+	BOOST_TEST(copy3.type() == jump_type::goto_jump);
+	BOOST_TEST(goto_stmt.type() == jump_type::goto_jump);
+	BOOST_TEST(copy4.type() == jump_type::return_jump);
+	BOOST_TEST(return_stmt1.type() == jump_type::return_jump);
+	BOOST_TEST(copy5.type() == jump_type::return_jump);
+	BOOST_TEST(return_stmt2.type() == jump_type::return_jump);
 
+	output.str("");
 	output << copy1;
+	BOOST_TEST(output.str() == indent + "break;\n");
+
+	output.str("");
+	output << copy2;
+	BOOST_TEST(output.str() == indent + "continue;\n");
+
+	output.str("");
+	output << copy3;
+	BOOST_TEST(output.str() == indent + "goto label;\n");
+
+	output.str("");
+	output << copy4;
+	BOOST_TEST(output.str() == indent + "return;\n");
+
+	output.str("");
+	output << copy5;
+	BOOST_TEST(output.str() == indent + "return 5;\n");
 
 	copy1 = continue_stmt;
+	copy2 = break_stmt;
+	copy5 = goto_stmt;
+	copy3 = return_stmt1;
+	copy4 = return_stmt2;
 
-	BOOST_TEST(copy1.type() == jump_type::continue_jump);
+	BOOST_TEST(copy2.type() == jump_type::break_jump);
 	BOOST_TEST(break_stmt.type() == jump_type::break_jump);
+	BOOST_TEST(copy1.type() == jump_type::continue_jump);
+	BOOST_TEST(continue_stmt.type() == jump_type::continue_jump);
+	BOOST_TEST(copy5.type() == jump_type::goto_jump);
+	BOOST_TEST(goto_stmt.type() == jump_type::goto_jump);
+	BOOST_TEST(copy3.type() == jump_type::return_jump);
+	BOOST_TEST(return_stmt1.type() == jump_type::return_jump);
+	BOOST_TEST(copy4.type() == jump_type::return_jump);
+	BOOST_TEST(return_stmt2.type() == jump_type::return_jump);
+
+	output.str("");
+	output << copy2;
+	BOOST_TEST(output.str() == indent + "break;\n");
+
+	output.str("");
+	output << copy1;
+	BOOST_TEST(output.str() == indent + "continue;\n");
+
+	output.str("");
+	output << copy5;
+	BOOST_TEST(output.str() == indent + "goto label;\n");
+
+	output.str("");
+	output << copy3;
+	BOOST_TEST(output.str() == indent + "return;\n");
+
+	output.str("");
+	output << copy4;
+	BOOST_TEST(output.str() == indent + "return 5;\n");
 }
 
 BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -751,9 +751,9 @@ BOOST_AUTO_TEST_CASE(jump_statement_tests)
 {
 	jump_statement break_stmt(jump_type::break_jump);
 	jump_statement continue_stmt(jump_type::continue_jump);
-	jump_statement goto_stmt(jump_type::goto_jump);
+	jump_statement goto_stmt(jump_type::goto_jump, make_unique<primitive_expression>("label"));
 	jump_statement return_stmt1(jump_type::return_jump);
-	jump_statement return_stmt2(jump_type::return_jump);
+	jump_statement return_stmt2(jump_type::return_jump, make_unique<primitive_expression>("5"));
 
 	BOOST_TEST(break_stmt.type() == jump_type::break_jump);
 	BOOST_TEST(continue_stmt.type() == jump_type::continue_jump);

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -588,6 +588,13 @@ BOOST_AUTO_TEST_CASE(case_statement_tests)
 	case_statement block(false);
 	BOOST_TEST(block.statements().size() == 0);
 
+	boost::test_tools::output_test_stream output;
+	auto indent = formatter_settings::settings.get_indent_string();
+
+	output << block;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + "}\n");
+
 	auto &body2 = block.statements();
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
 	body2.emplace_back(make_unique<expression_statement>(make_unique<primitive_expression>("2")));
@@ -596,31 +603,63 @@ BOOST_AUTO_TEST_CASE(case_statement_tests)
 
 	auto &var = block.label();
 
-	boost::test_tools::output_test_stream output;
+	output.str("");
 	output << block;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	auto copy2(block);
 
 	BOOST_TEST(copy2.statements().size() == 2);
 	BOOST_TEST(block.statements().size() == 2);
 
+	output.str("");
+	output << copy2;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
+
+	output.str("");
+	output << copy2;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	copy2 = block;
 
 	BOOST_TEST(copy2.statements().size() == 3);
 	BOOST_TEST(block.statements().size() == 3);
 
+	output.str("");
 	output << copy2;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n");
 
 	case_statement block2(make_unique<primitive_expression>("5"));
 	auto &var2 = block2.label();
 	BOOST_TEST(dynamic_cast<const primitive_expression &>(var2).expr() == "5");
 
+	output.str("");
+	output << block2;
+
+	BOOST_TEST(output.str() == indent + "case 5:\n" + indent + "{\n" + indent + "}\n");
+
+	auto copy3(block2);
+
+	output.str("");
+	output << copy3;
+
+	BOOST_TEST(output.str() == indent + "case 5:\n" + indent + "{\n" + indent + "}\n");
+
 	const auto &c_ref = copy2;
 	c_ref.has_label();
 	c_ref.label();
 	c_ref.statements();
+
+	output.str("");
+	output << c_ref;
+
+	BOOST_TEST(output.str() == indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n");
 }
 
 BOOST_AUTO_TEST_CASE(switch_statement_tests)

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -669,6 +669,13 @@ BOOST_AUTO_TEST_CASE(switch_statement_tests)
 	BOOST_TEST(stmt->cases().size() == 0);
 	BOOST_TEST(dynamic_cast<const primitive_expression &>(stmt->condition()).expr() == "5");
 
+	boost::test_tools::output_test_stream stream;
+	auto indent = formatter_settings::settings.get_indent_string();
+
+	stream << *stmt;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "}\n");
+
 	case_statement block(true);
 	auto &body3 = block.statements();
 	body3.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
@@ -678,13 +685,27 @@ BOOST_AUTO_TEST_CASE(switch_statement_tests)
 
 	BOOST_TEST(stmt->cases().size() == 1);
 
+	stream.str("");
+	stream << *stmt;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
+
 	auto other = stmt->clone();
 
-	boost::test_tools::output_test_stream stream;
-
+	stream.str("");
 	stream << *other;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
+
+	stream.str("");
 	other->write(stream);
-	stream << *stmt;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
+
+	stream.str("");
+	stream << *other;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
 
 	auto copy2(*stmt);
 
@@ -694,19 +715,36 @@ BOOST_AUTO_TEST_CASE(switch_statement_tests)
 
 	stmt->cases().push_back(block);
 
+	stream.str("");
+	stream << copy2;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
+
 	copy2 = *stmt;
+
+	stream.str("");
+	stream << copy2;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
 
 	BOOST_TEST(copy2.cases().size() == 2);
 	BOOST_TEST(stmt->cases().size() == 2);
 	BOOST_TEST(dynamic_cast<const primitive_expression &>(copy2.condition()).expr() == "5");
 
+	stream.str("");
 	stream << copy2;
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
 
 	const auto &c_ref = copy2;
 	c_ref.cases();
 	c_ref.condition();
 	c_ref.clone();
+
+	stream.str("");
 	c_ref.write(stream);
+
+	BOOST_TEST(stream.str() == indent + "switch(5)\n" + indent + "{\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "default:\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "}\n");
 }
 
 BOOST_AUTO_TEST_CASE(jump_statement_tests)


### PR DESCRIPTION
Fixes uninitialized member access when writing out a goto statement or a return statement.

Adds the missing `;` at the end of goto statement.