### PR TITLE
Other/ranged for loop init changes

### DIFF
--- a/src/features/statements/ranged_for_loop.cpp
+++ b/src/features/statements/ranged_for_loop.cpp
@@ -1,8 +1,8 @@
 #include "ranged_for_loop.h"
+#include "../../formatters/formatter_settings.h"
 #include "../declarations/variable_declaration.h"
 #include "../expressions/primitive_expression.h"
 #include "../types/primitive_type.h"
-#include "../../formatters/formatter_settings.h"
 
 using namespace std;
 using namespace cpp::codeprovider::declarations;
@@ -10,9 +10,9 @@ using namespace cpp::codeprovider::formatting;
 using namespace cpp::codeprovider::statements;
 using namespace cpp::codeprovider::types;
 
-namespace
+ranged_for_loop::ranged_for_loop(unique_ptr<variable_declaration> d)
+	: init(move(d))
 {
-variable_declaration placeholder(declarator_specifier(make_shared<primitive_type>("")));
 }
 
 unique_ptr<statement> ranged_for_loop::clone() const
@@ -34,7 +34,7 @@ void ranged_for_loop::write(ostream &os) const
 
 const variable_declaration &ranged_for_loop::initializer() const
 {
-	return init ? *init : placeholder;
+	return *init;
 }
 
 ranged_for_loop &ranged_for_loop::initializer(unique_ptr<variable_declaration> i)

--- a/src/features/statements/ranged_for_loop.cpp
+++ b/src/features/statements/ranged_for_loop.cpp
@@ -26,9 +26,9 @@ void ranged_for_loop::write(ostream &os) const
 
 	if (comment.size() > 0)
 		os << indent << "//" << comment << endl;
-	os << indent << "for( ";
-	os << init->specifier() << ':' << *init->var_declarator().initializer_exp;
-	os << " )" << endl;
+	os << indent << "for(";
+	os << init->specifier() << init->var_declarator().name << " : " << *init->var_declarator().initializer_exp;
+	os << ")" << endl;
 	os << body;
 }
 

--- a/src/features/statements/ranged_for_loop.cpp
+++ b/src/features/statements/ranged_for_loop.cpp
@@ -1,15 +1,18 @@
 #include "ranged_for_loop.h"
+#include "../declarations/variable_declaration.h"
 #include "../expressions/primitive_expression.h"
+#include "../types/primitive_type.h"
 #include "../../formatters/formatter_settings.h"
 
 using namespace std;
-using namespace cpp::codeprovider::expressions;
+using namespace cpp::codeprovider::declarations;
 using namespace cpp::codeprovider::formatting;
 using namespace cpp::codeprovider::statements;
+using namespace cpp::codeprovider::types;
 
 namespace
 {
-primitive_expression placeholder("");
+variable_declaration placeholder(declarator_specifier(make_shared<primitive_type>("")));
 }
 
 unique_ptr<statement> ranged_for_loop::clone() const
@@ -24,18 +27,17 @@ void ranged_for_loop::write(ostream &os) const
 	if (comment.size() > 0)
 		os << indent << "//" << comment << endl;
 	os << indent << "for( ";
-	if (init)
-		os << *init;
+	os << init->specifier() << ':' ;//<< *(init->var_declarator().initializer_exp());
 	os << " )" << endl;
 	os << body;
 }
 
-const expression &ranged_for_loop::initializer() const
+const variable_declaration &ranged_for_loop::initializer() const
 {
 	return init ? *init : placeholder;
 }
 
-ranged_for_loop &ranged_for_loop::initializer(unique_ptr<expression> i)
+ranged_for_loop &ranged_for_loop::initializer(unique_ptr<variable_declaration> i)
 {
 	init = move(i);
 	return *this;

--- a/src/features/statements/ranged_for_loop.cpp
+++ b/src/features/statements/ranged_for_loop.cpp
@@ -27,7 +27,7 @@ void ranged_for_loop::write(ostream &os) const
 	if (comment.size() > 0)
 		os << indent << "//" << comment << endl;
 	os << indent << "for( ";
-	os << init->specifier() << ':' ;//<< *(init->var_declarator().initializer_exp());
+	os << init->specifier() << ':' << *init->var_declarator().initializer_exp;
 	os << " )" << endl;
 	os << body;
 }

--- a/src/features/statements/ranged_for_loop.h
+++ b/src/features/statements/ranged_for_loop.h
@@ -17,12 +17,12 @@ namespace statements
 class ranged_for_loop : public statement
 {
 	block_statement body;
-	utils::copyable_ptr<expressions::expression> init;
+	utils::copyable_ptr<declarations::variable_declaration> init;
 
 public:
 	ranged_for_loop() = default;
 
-	ACCESSOR_DECLARATION_2(ranged_for_loop, initializer, const expressions::expression &, std::unique_ptr<expressions::expression>)
+	ACCESSOR_DECLARATION_2(ranged_for_loop, initializer, const declarations::variable_declaration &, std::unique_ptr<declarations::variable_declaration>)
 	statement_list &statements();
 	const statement_list &statements() const;
 

--- a/src/features/statements/ranged_for_loop.h
+++ b/src/features/statements/ranged_for_loop.h
@@ -20,7 +20,7 @@ class ranged_for_loop : public statement
 	utils::copyable_ptr<declarations::variable_declaration> init;
 
 public:
-	ranged_for_loop() = default;
+	ranged_for_loop(std::unique_ptr<declarations::variable_declaration>);
 
 	ACCESSOR_DECLARATION_2(ranged_for_loop, initializer, const declarations::variable_declaration &, std::unique_ptr<declarations::variable_declaration>)
 	statement_list &statements();

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -861,9 +861,14 @@ BOOST_AUTO_TEST_CASE(jump_statement_tests)
 
 BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 {
-	auto stmt = make_unique<ranged_for_loop>();
+	auto var = make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("int")));
+	var->var_declarator().name = "i";
+	var->var_declarator().initializer_exp = copyable_ptr<expression>(make_unique<primitive_expression>("55"));
+	auto stmt = make_unique<ranged_for_loop>(move(var));
 
 	BOOST_TEST(stmt->statements().size() == 0);
+	BOOST_TEST(dynamic_cast<const variable_declaration &>(stmt->initializer()).var_declarator().name == "i");
+	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(stmt->initializer()).var_declarator().initializer_exp).expr() == "55");
 
 	boost::test_tools::output_test_stream stream;
 
@@ -875,14 +880,6 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 	body2.emplace_back(make_unique<expression_statement>(make_unique<primitive_expression>("2")));
 
 	BOOST_TEST(stmt->statements().size() == 2);
-	BOOST_TEST(dynamic_cast<const primitive_expression &>(stmt->initializer()).expr() == "");
-
-	auto var = make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("int")));
-	var->var_declarator().name = "i";
-	var->var_declarator().initializer_exp = copyable_ptr<expression>(make_unique<primitive_expression>("55"));
-	stmt->initializer(move(var));
-
-	BOOST_TEST(dynamic_cast<const primitive_expression &>(stmt->initializer()).expr() == "1");
 
 	auto other = stmt->clone();
 
@@ -890,10 +887,9 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 	other->write(stream);
 
 	auto copy2(*stmt);
-	BOOST_TEST(stmt->statements().size() == 2);
-	BOOST_TEST(dynamic_cast<const variable_declaration &>(stmt->initializer()).var_declarator().name == "i");
 	BOOST_TEST(copy2.statements().size() == 2);
-	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(stmt->initializer()).var_declarator().initializer_exp).expr() == "55");
+	BOOST_TEST(dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().name == "i");
+	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().initializer_exp).expr() == "55");
 
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
 
@@ -901,6 +897,8 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 
 	BOOST_TEST(stmt->statements().size() == 3);
 	BOOST_TEST(copy2.statements().size() == 3);
+	BOOST_TEST(dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().name == "i");
+	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().initializer_exp).expr() == "55");
 
 	const auto &c_ref = copy2;
 	c_ref.clone();

--- a/tests/features/statements/statement_tests.cpp
+++ b/tests/features/statements/statement_tests.cpp
@@ -871,8 +871,11 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(stmt->initializer()).var_declarator().initializer_exp).expr() == "55");
 
 	boost::test_tools::output_test_stream stream;
+	auto indent = formatter_settings::settings.get_indent_string();
 
 	stream << *stmt;
+
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + "}\n");
 
 	auto &body2 = stmt->statements();
 
@@ -881,19 +884,38 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 
 	BOOST_TEST(stmt->statements().size() == 2);
 
+	stream.str("");
+	stream << *stmt;
+
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	auto other = stmt->clone();
 
+	stream.str("");
 	stream << *other;
+
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
+	stream.str("");
 	other->write(stream);
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
 
 	auto copy2(*stmt);
 	BOOST_TEST(copy2.statements().size() == 2);
 	BOOST_TEST(dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().name == "i");
 	BOOST_TEST(dynamic_cast<const primitive_expression&>(*dynamic_cast<const variable_declaration &>(copy2.initializer()).var_declarator().initializer_exp).expr() == "55");
 
+	stream.str("");
+	stream << copy2;
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + "}\n");
+
 	body2.push_back(make_unique<expression_statement>(make_unique<primitive_expression>("1")));
 
 	copy2 = *stmt;
+
+	stream.str("");
+	stream << copy2;
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n");
 
 	BOOST_TEST(stmt->statements().size() == 3);
 	BOOST_TEST(copy2.statements().size() == 3);
@@ -905,6 +927,10 @@ BOOST_AUTO_TEST_CASE(ranged_for_loop_tests)
 	c_ref.initializer();
 	c_ref.statements();
 	c_ref.write(stream);
+
+	stream.str("");
+	stream << copy2;
+	BOOST_TEST(stream.str() == indent + "for(int i : 55)\n" + indent + "{\n" + indent + indent + "1;\n" + indent + indent + "2;\n" + indent + indent + "1;\n" + indent + "}\n");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Changed ranged_for_loop initializer to take variable_declaration as parameter, rather than a simple expression.

