### PR TITLE
function and member_function can return their names.

### DIFF
--- a/src/features/functions/function.cpp
+++ b/src/features/functions/function.cpp
@@ -72,6 +72,7 @@ ACCESSOR_IMPL_2(function, has_trailing_return_type, bool, impl.has_trailing_retu
 ACCESSOR_IMPL_2(function, is_var_arg, bool, impl.is_var_arg)
 ACCESSOR_IMPL_2(function, is_no_except, bool, impl.is_no_except)
 ACCESSOR_IMPL_2(function, no_except_expr, copyable_ptr<expression>, impl.no_except_expr)
+ACCESSOR_IMPL_3(function, name, string, impl.name, const string&)
 
 block_statement &function::body()
 {

--- a/src/features/functions/function.h
+++ b/src/features/functions/function.h
@@ -40,6 +40,7 @@ public:
 	ACCESSOR_DECLARATION(function, is_var_arg, bool);
 	ACCESSOR_DECLARATION(function, is_no_except, bool);
 	ACCESSOR_DECLARATION(function, no_except_expr, utils::copyable_ptr<expressions::expression>);
+	ACCESSOR_DECLARATION_2(function, name, std::string, const std::string&);
 	statements::block_statement &body();
 	const statements::block_statement &body() const;
 	std::ostream &write_declaration(std::ostream &) const override;

--- a/src/features/functions/member_function.cpp
+++ b/src/features/functions/member_function.cpp
@@ -131,6 +131,7 @@ ACCESSOR_IMPL_2(member_function, has_trailing_return_type, bool, impl.has_traili
 ACCESSOR_IMPL_2(member_function, is_var_arg, bool, impl.is_var_arg)
 ACCESSOR_IMPL_2(member_function, is_no_except, bool, impl.is_no_except)
 ACCESSOR_IMPL_2(member_function, no_except_expr, copyable_ptr<expression>, impl.no_except_expr)
+ACCESSOR_IMPL_3(member_function, name, string, impl.name, const string&)
 
 ostream &member_function::write_declaration(ostream &os) const
 {

--- a/src/features/functions/member_function.h
+++ b/src/features/functions/member_function.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
+#include "../../utils/dirty_macros.h"
+#include "../internals/write_backlog_entry.h"
+#include "../types/access_levels.h"
+#include "callable.h"
 #include <memory>
 #include <string>
 #include <vector>
-#include "callable.h"
-#include "../internals/write_backlog_entry.h"
-#include "../types/access_levels.h"
-#include "../../utils/dirty_macros.h"
 
 namespace cpp
 {
@@ -66,6 +66,7 @@ public:
 	ACCESSOR_DECLARATION(member_function, is_var_arg, bool);
 	ACCESSOR_DECLARATION(member_function, is_no_except, bool);
 	ACCESSOR_DECLARATION(member_function, no_except_expr, utils::copyable_ptr<expressions::expression>);
+	ACCESSOR_DECLARATION_2(member_function, name, std::string, const std::string &);
 	statements::block_statement &body();
 	const statements::block_statement &body() const;
 	std::ostream &write_declaration(std::ostream &) const;

--- a/src/utils/dirty_macros.h
+++ b/src/utils/dirty_macros.h
@@ -35,4 +35,16 @@
         return field_name;                                                  \
     }
 
+#define ACCESSOR_IMPL_3(typeName, accessor_name, accessor_type, field_name, parameter_type) \
+    typeName &typeName::accessor_name(parameter_type val)                    \
+    {                                                                       \
+        field_name = val;                                                   \
+        return *this;                                                       \
+    }                                                                       \
+                                                                            \
+    accessor_type typeName::accessor_name() const                           \
+    {                                                                       \
+        return field_name;                                                  \
+    }
+
 #endif

--- a/tests/features/functions/function_tests.cpp
+++ b/tests/features/functions/function_tests.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	BOOST_TEST(f1.return_type()->get_name() == "int");
 	BOOST_TEST(f1.catch_blocks().size() == 0);
 	BOOST_TEST(!f1.no_except_expr().operator->());
+	BOOST_TEST(f1.name() == "something");
 
 	boost::test_tools::output_test_stream stream;
 	auto indent = formatter_settings::settings.get_indent_string();
@@ -62,14 +63,17 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	f1.template_parameters().emplace_back(make_unique<template_parameter>("T"));
 	f1.catch_blocks().push_back(block);
 	f1.parameters().emplace_back(make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("int"))));
+	f1.name("abcd");
+
+	BOOST_TEST(f1.name() == "abcd");
 
 	stream.str("");
 	f1.write_declaration(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto something(int , ...) noexcept -> int;\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto abcd(int , ...) noexcept -> int;\n");
 
 	stream.str("");
 	f1.write_definition(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto something(int , ...) noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto abcd(int , ...) noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
 
 	auto copy1(f1);
 
@@ -85,14 +89,15 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	BOOST_TEST(copy1.template_parameters().size() == 1);
 	BOOST_TEST(copy1.return_type()->get_name() == "int");
 	BOOST_TEST(copy1.catch_blocks().size() == 1);
+	BOOST_TEST(copy1.name() == "abcd");
 
 	stream.str("");
 	copy1.write_declaration(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto something(int , ...) noexcept -> int;\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto abcd(int , ...) noexcept -> int;\n");
 
 	stream.str("");
 	copy1.write_definition(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto something(int , ...) noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static auto abcd(int , ...) noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
 
 	f1.is_inline(false);
 	f1.is_static(false);
@@ -105,6 +110,7 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	f1.template_parameters().emplace_back(make_unique<template_parameter>("U"));
 	f1.catch_blocks().push_back(block);
 	f1.parameters().emplace_back(make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("T"))));
+	f1.name("something");
 
 	stream.str("");
 	f1.write_declaration(stream);
@@ -127,6 +133,7 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	BOOST_TEST(copy1.template_parameters().size() == 2);
 	BOOST_TEST(copy1.return_type()->get_name() == "int");
 	BOOST_TEST(copy1.catch_blocks().size() == 2);
+	BOOST_TEST(copy1.name() == "something");
 
 	copy1.is_no_except(false);
 
@@ -149,6 +156,7 @@ BOOST_AUTO_TEST_CASE(function_tests)
 	c_ref.has_trailing_return_type();
 	c_ref.is_var_arg();
 	c_ref.is_no_except();
+	c_ref.name();
 
 	stream.str("");
 	c_ref.write_declaration(stream);
@@ -183,6 +191,7 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	BOOST_TEST(f1.return_type()->get_name() == "int");
 	BOOST_TEST(f1.catch_blocks().size() == 0);
 	BOOST_TEST(!f1.no_except_expr().operator->());
+	BOOST_TEST(f1.name() == "something");
 
 	boost::test_tools::output_test_stream stream;
 	auto indent = formatter_settings::settings.get_indent_string();
@@ -212,14 +221,17 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	f1.template_parameters().emplace_back(make_unique<template_parameter>("T"));
 	f1.catch_blocks().push_back(block);
 	f1.parameters().emplace_back(make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("int"))));
+	f1.name("abcd");
+
+	BOOST_TEST(f1.name() == "abcd");
 
 	stream.str("");
 	f1.write_declaration(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto something(int , ...) const volatile override final noexcept = 0 -> int;\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto abcd(int , ...) const volatile override final noexcept = 0 -> int;\n");
 
 	stream.str("");
 	f1.write_definition(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto udt::something(int , ...) const volatile override noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto udt::abcd(int , ...) const volatile override noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
 
 	auto copy1(f1);
 
@@ -241,14 +253,15 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	BOOST_TEST(copy1.template_parameters().size() == 1);
 	BOOST_TEST(copy1.return_type()->get_name() == "int");
 	BOOST_TEST(copy1.catch_blocks().size() == 1);
+	BOOST_TEST(copy1.name() == "abcd");
 
 	stream.str("");
 	copy1.write_declaration(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto something(int , ...) const volatile override final noexcept = 0 -> int;\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto abcd(int , ...) const volatile override final noexcept = 0 -> int;\n");
 
 	stream.str("");
 	copy1.write_definition(stream);
-	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto udt::something(int , ...) const volatile override noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
+	BOOST_TEST(stream.str() == "template<typename T> constexpr inline static virtual auto udt::abcd(int , ...) const volatile override noexcept -> int\n" + indent + "try\n" + indent + "{\n" + indent + indent + "2;\n" + indent + "}\n" + indent + "catch(...)\n" + indent + "{\n" + indent + "}\n");
 
 	f1.is_inline(false);
 	f1.is_static(false);
@@ -267,6 +280,7 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	f1.template_parameters().emplace_back(make_unique<template_parameter>("U"));
 	f1.catch_blocks().push_back(block);
 	f1.parameters().emplace_back(make_unique<variable_declaration>(declarator_specifier(make_unique<primitive_type>("T"))));
+	f1.name("something");
 
 	stream.str("");
 	f1.write_declaration(stream);
@@ -297,6 +311,7 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	BOOST_TEST(copy1.template_parameters().size() == 2);
 	BOOST_TEST(copy1.return_type()->get_name() == "int");
 	BOOST_TEST(copy1.catch_blocks().size() == 2);
+	BOOST_TEST(copy1.name() == "something");
 
 	copy1.is_no_except(false);
 
@@ -327,6 +342,7 @@ BOOST_AUTO_TEST_CASE(member_function_tests)
 	c_ref.has_trailing_return_type();
 	c_ref.is_var_arg();
 	c_ref.is_no_except();
+	c_ref.name();
 
 	stream.str("");
 	c_ref.write_declaration(stream);


### PR DESCRIPTION
Fixes the issue where it was not possible to know what name a function or member_function had.